### PR TITLE
Quoting a glob causes it to not be expanded by the shell

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -25,7 +25,7 @@ const dest = path.resolve(moduleDir, patchDir);
 
 try {
   console.log(`ℹ️  Patching ${dest}.`);
-  execSync(`cp -R "${__dirname}/rn-renderer/*" "${dest}"`, { stdio: "inherit" });
+  execSync(`find "${input}" -type f -exec cp {} "${dest}" \\;`, { stdio: "inherit" });
   console.log("✅  Patch successful.\n");
 } catch (error) {
   console.log(`❌  Error: ${error.message}`);


### PR DESCRIPTION
The `*` does not get expanded when quoted, so #2 breaks this package. Using `find` is a better alternative to avoid whitespace-related issues.